### PR TITLE
Fix boundary marker addition when no materials exist yet.

### DIFF
--- a/gamer_addon/boundary_markers.py
+++ b/gamer_addon/boundary_markers.py
@@ -351,9 +351,24 @@ class GAMerBoundaryMarkersPropertyGroup(bpy.types.PropertyGroup):
             obj['boundaries'][bnd_id]['faces'] = {}
 
         mats = bpy.data.materials
-        bnd_mat_name = "%s_mat" % (bnd_id)
-        
+
+        # Check if the bnd_unset material exists already...
+        bnd_unset_mat = None    # set scope
+        matches = [ mat for mat in mats if mat.gamer.boundary_id == 'bnd_unset' ]
+        if len(matches) == 0:
+            # Doesn't exist yet... create it
+            bnd_unset_mat = bpy.data.materials.new('bnd_unset_mat') 
+            bnd_unset_mat.gamer.boundary_id = 'bnd_unset'
+        else:
+            bnd_unset_mat = matches[0]
+
+        # Check if the default material is set to bnd_unset  
+        if len(obj.material_slots) == 0:
+            bpy.ops.object.material_slot_add()
+            obj.material_slots[0].material = bnd_unset_mat
+
         # Search for mat with boundary_id...
+        bnd_mat_name = "%s_mat" % (bnd_id)
         mat_list = [ mat for mat in mats if mat.gamer.boundary_id == bnd_id ]
         if len(mat_list) == 0:
           bnd_mat = bpy.data.materials.new(bnd_mat_name)
@@ -361,13 +376,6 @@ class GAMerBoundaryMarkersPropertyGroup(bpy.types.PropertyGroup):
         else:
           bnd_mat = mat_list[0]
        
-        """
-        if len(obj.material_slots) == 0:
-          bpy.ops.object.material_slot_add()
-          bnd_mat = [ mat for mat in mats if mat.gamer.boundary_id == bnd_id ][0]
-          obj.material_slots[0].material = bnd_mat
-        """
-
         bpy.ops.object.material_slot_add()
         obj.material_slots[-1].material = bnd_mat
         

--- a/gamer_addon/boundary_markers.py
+++ b/gamer_addon/boundary_markers.py
@@ -351,21 +351,25 @@ class GAMerBoundaryMarkersPropertyGroup(bpy.types.PropertyGroup):
             obj['boundaries'][bnd_id]['faces'] = {}
 
         mats = bpy.data.materials
-        if len(obj.material_slots) == 0:
-          bpy.ops.object.material_slot_add()
-          bnd_unset_mat = [ mat for mat in mats if mat.gamer.boundary_id == 'bnd_unset' ][0]
-          obj.material_slots[0].material = bnd_unset_mat
-
         bnd_mat_name = "%s_mat" % (bnd_id)
+        
+        # Search for mat with boundary_id...
         mat_list = [ mat for mat in mats if mat.gamer.boundary_id == bnd_id ]
         if len(mat_list) == 0:
           bnd_mat = bpy.data.materials.new(bnd_mat_name)
           bnd_mat.gamer.boundary_id = bnd_id
         else:
           bnd_mat = mat_list[0]
+       
+        """
+        if len(obj.material_slots) == 0:
+          bpy.ops.object.material_slot_add()
+          bnd_mat = [ mat for mat in mats if mat.gamer.boundary_id == bnd_id ][0]
+          obj.material_slots[0].material = bnd_mat
+        """
+
         bpy.ops.object.material_slot_add()
         obj.material_slots[-1].material = bnd_mat
-        
         
 
 

--- a/gamer_addon/boundary_markers.py
+++ b/gamer_addon/boundary_markers.py
@@ -359,6 +359,12 @@ class GAMerBoundaryMarkersPropertyGroup(bpy.types.PropertyGroup):
             # Doesn't exist yet... create it
             bnd_unset_mat = bpy.data.materials.new('bnd_unset_mat') 
             bnd_unset_mat.gamer.boundary_id = 'bnd_unset'
+            
+            # Update all materials which don't have a gamer boundaryID yet
+            for slot in obj.material_slots:
+                # Blender created materials should have '' as boundary_id
+                if slot.material.gamer.boundary_id == '':
+                    slot.material = bnd_unset_mat
         else:
             bnd_unset_mat = matches[0]
 


### PR DESCRIPTION
This patches fixes the issue that follows:  In the case of opening a Blender save where no materials were used (Blender will not save the materials), there could be no materials existing leading to an error. Thus, instead of checking if a new material should be created later, it is done first prior to the creation of the new material association for the object. In this case, since the existence of the material is always checked, and created if missing, it will always exist for all cases.


Here are some of my notes on how to recreate the error:

For some reason I'm getting the following error when adding a boundary marking. There are some special conditions in which this occurs as follows:

1. I have opened a saved .blend file generated by the latest Blender/GAMer/CellBlender combination where no materials exist. There is no error if it isn't opened from a save.
2. It's the first click of add_boundary. Later clicks generate the materials correctly
3. If I define a material for an object first, then there is no error for the first click.

```
location: <unknown location>:-1

Traceback (most recent call last):

  File "/Users/ctlee/Library/Application Support/Blender/2.77/scripts/addons/gamer_addon/boundary_markers.py", line 143, in draw_item

    bnd_mat = [ mat for mat in mats if mat.gamer.boundary_id == item.boundary_id ][0]

IndexError: list index out of range

location: /Users/ctlee/Library/Application Support/Blender/2.77/scripts/addons/gamer_addon/boundary_markers.py:657

location: /Users/ctlee/Library/Application Support/Blender/2.77/scripts/addons/gamer_addon/boundary_markers.py:657

Traceback (most recent call last):

  File "/Users/ctlee/Library/Application Support/Blender/2.77/scripts/addons/gamer_addon/gamer_gui.py", line 308, in draw

    context.scene.gamer.main_panel.draw_self(context,self.layout)

  File "/Users/ctlee/Library/Application Support/Blender/2.77/scripts/addons/gamer_addon/gamer_gui.py", line 273, in draw_self

    active_obj.gamer.draw_layout ( context, layout )

  File "/Users/ctlee/Library/Application Support/Blender/2.77/scripts/addons/gamer_addon/boundary_markers.py", line 677, in draw_layout

    bnd_mat = [ mat for mat in mats if mat.gamer.boundary_id == active_bnd.boundary_id ][0]

IndexError: list index out of range
```